### PR TITLE
Remove Triton URL from repo / Link to QuickNode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "8080:8080"
     environment:
       - RUST_LOG=debug
-      - JUPITER_API_URL=https://bulk.rpcpool.com/1e245781-b06d-4601-b628-61babccfcfa2/jupiter/quote
+      - JUPITER_API_URL=https://public.jupiterapi.com
       - IP_ADDRESS=0.0.0.0
       - PORT=8080
     restart: always

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Bulk Price Engine is a Rust-based WebSocket server that provides real-time price
 
 2. Create a `.env` file in the project root and add the following environment variables:
    ```
-   JUPITER_API_URL=https://quote-api.jup.ag/v6/quote
+   JUPITER_API_URL=https://public.jupiterapi.com
    IP_ADDRESS=0.0.0.0
    PORT=8080
    ```
@@ -152,7 +152,7 @@ The Bulk Price Engine will now be running and accessible at `http://localhost:80
 You can modify the following environment variables in the `docker-compose.yml` file:
 
 - `RUST_LOG`: Set the log level (e.g., debug, info, warn)
-- `JUPITER_API_URL`: The URL for the Jupiter API
+- `JUPITER_API_URL`: The URL for the Jupiter API [Hosted Jupiter Swap API](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api)
 - `IP_ADDRESS`: The IP address to bind to (default: 0.0.0.0)
 - `PORT`: The port to run the application on (default: 8080)
 


### PR DESCRIPTION
Thanks for building this tool! Noticed you were leaking your Triton credentials, so I updated to use the public good from QuickNode - [JupiterAPI.com](https://www.jupiterapi.com) - did it for a couple reasons:

1. Remove your Triton credentials so other people can't run up your bill
2. Give users higher rate limits than the Jupiter hosted API

> Note: JupiterAPI.com charges 20 bps per trade, it's how we continue to offer it for free.

I also linked to QuickNode's paid version of Jupiter Swap API in the README.

